### PR TITLE
Switch to verified https requests

### DIFF
--- a/slack/http_client.py
+++ b/slack/http_client.py
@@ -33,13 +33,13 @@ from slack.exception import SlackError, \
 
 def get(method, params):
     url = _build_url(method)
-    response = requests.get(url, params=params, verify=False).json()
+    response = requests.get(url, params=params, verify=True).json()
     _raise_error_if_not_ok(response)
     return response
 
 def post(method, data):
     url = _build_url(method)
-    response = requests.post(url, data=data, verify=False).json()
+    response = requests.post(url, data=data, verify=True).json()
     _raise_error_if_not_ok(response)
     return response
 


### PR DESCRIPTION
With newer versions of urllib3 (starting with 1.9), any HTTPS requests made with certificate verification turned off will kick off a warning.  Turning on certificate verification will eliminate this warning.

See https://urllib3.readthedocs.org/en/latest/security.html#insecurerequestwarning
