### PR TITLE
Handle api.slack.com returning invalid JSON responses

### DIFF
--- a/slack/http_client.py
+++ b/slack/http_client.py
@@ -33,13 +33,17 @@ from slack.exception import SlackError, \
 
 def get(method, params):
     url = _build_url(method)
-    response = requests.get(url, params=params, verify=True).json()
-    _raise_error_if_not_ok(response)
-    return response
+    return _parse_response(requests.get(url, params=params, verify=True))
 
 def post(method, data):
     url = _build_url(method)
-    response = requests.post(url, data=data, verify=True).json()
+    return _parse_response(requests.post(url, data=data, verify=True))
+
+def _parse_response(response):
+    try:
+        response = response.json()
+    except ValueError as e:
+        _raise_error_if_not_ok({'ok': False, 'error': e})
     _raise_error_if_not_ok(response)
     return response
 

--- a/slack/http_client.py
+++ b/slack/http_client.py
@@ -33,17 +33,19 @@ from slack.exception import SlackError, \
 
 def get(method, params):
     url = _build_url(method)
-    return _parse_response(requests.get(url, params=params, verify=True))
+    response = requests.get(url, params=params, verify=True)
+    return _parse_response(response)
 
 def post(method, data):
     url = _build_url(method)
-    return _parse_response(requests.post(url, data=data, verify=True))
+    response = requests.post(url, data=data, verify=True)
+    return _parse_response(response)
 
 def _parse_response(response):
     try:
         response = response.json()
     except ValueError as e:
-        _raise_error_if_not_ok({'ok': False, 'error': e})
+        response = {'ok': False, 'error': e}
     _raise_error_if_not_ok(response)
     return response
 

--- a/tests/unit/http_client/test_parse_response.py
+++ b/tests/unit/http_client/test_parse_response.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2014 Katsuya Noguchi
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+import json
+import mock
+import unittest
+
+import slack.http_client
+from slack.exception import SlackError
+
+
+class TestParseResponseClient(unittest.TestCase):
+    def _get_mock_response(self, response):
+        return mock.Mock(json=lambda: json.loads(response))
+
+    def test_invalid_json(self):
+        invalid_response = self._get_mock_response('')
+        self.assertRaises(SlackError,
+                          slack.http_client._parse_response,
+                          invalid_response)
+
+    def test_bad_response(self):
+        bad_response = self._get_mock_response(
+            json.dumps({'ok': False, 'error': 'unknown_error'}))
+        self.assertRaises(SlackError,
+                          slack.http_client._parse_response,
+                          bad_response)
+
+    def test_ok_response(self):
+        # does not raise
+        ok_response = self._get_mock_response(json.dumps({'ok': True}))
+        slack.http_client._parse_response(ok_response)


### PR DESCRIPTION
Written quickly while waiting for `api.slack.com` to come back online :)
