### PR TITLE
Add an encoder for the `blocks` field

### DIFF
--- a/slack/chat.py
+++ b/slack/chat.py
@@ -29,7 +29,8 @@ def default_encoder(value): return value
 
 
 FIELD_ENCODERS = {
-    'attachments': json.dumps
+    'attachments': json.dumps,
+    'blocks': json.dumps,
 }
 
 


### PR DESCRIPTION
This is useful for using [layout blocks](https://api.slack.com/messaging/composing/layouts) (the new version of slack attachments).